### PR TITLE
chore: remove desktop release job from GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,30 +63,3 @@ jobs:
         with:
           files: build/compress/*
           prerelease: false
-
-  release_desktop:
-    needs: release
-    name: Release desktop
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          repository: alist-org/desktop-release
-          ref: main
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Add tag
-        run: |
-          git config --local user.email "bot@nn.ci"
-          git config --local user.name "IlaBot"
-          version=$(wget -qO- -t1 -T2 "https://api.github.com/repos/alist-org/alist/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
-          git tag -a $version -m "release $version"
-
-      - name: Push tags
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.MY_TOKEN }}
-          branch: main
-          repository: alist-org/desktop-release


### PR DESCRIPTION
- Deleted the 'release_desktop' job from the release.yml workflow as it is no longer necessary for the release process.