### PR TITLE
fix: adjust concurrency settings based on range length

### DIFF
--- a/internal/net/request.go
+++ b/internal/net/request.go
@@ -165,6 +165,9 @@ func (d *downloader) download() (io.ReadCloser, error) {
 	if maxPart < d.cfg.Concurrency {
 		d.cfg.Concurrency = maxPart
 	}
+	if d.params.Range.Length == 0 {
+		d.cfg.Concurrency = 1
+	}
 	log.Debugf("cfgConcurrency:%d", d.cfg.Concurrency)
 
 	if d.cfg.Concurrency == 1 {


### PR DESCRIPTION
- Set concurrency to 1 if the range length parameter is zero to ensure proper handling of downloads.