### PR TITLE
fix: update web version source in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ elif [ "$1" = "beta" ]; then
 else
   git tag -d beta
   version=$(git describe --abbrev=0 --tags)
-  webVersion=$(wget -qO- -t1 -T2 "https://api.github.com/repos/alist-org/alist-web/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
+  webVersion=$(wget -qO- -t1 -T2 "https://api.github.com/repos/AlliotTech/openalist-web/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
 fi
 
 echo "backend version: $version"


### PR DESCRIPTION
- Changed the API endpoint in build.sh to fetch the latest web version from the AlliotTech repository instead of alist-org.