### PR TITLE
refactor: move Content-Disposition generation to utils package

### DIFF
--- a/drivers/doubao/driver.go
+++ b/drivers/doubao/driver.go
@@ -145,7 +145,7 @@ func (d *Doubao) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 		}
 
 		// 生成标准的Content-Disposition
-		contentDisposition := generateContentDisposition(u.Name)
+		contentDisposition := utils.GenerateContentDisposition(u.Name)
 
 		return &model.Link{
 			URL: downloadUrl,

--- a/drivers/doubao/util.go
+++ b/drivers/doubao/util.go
@@ -925,35 +925,7 @@ func getSigningKey(secretKey, dateStamp, region, service string) []byte {
 	return kSigning
 }
 
-// generateContentDisposition 生成符合RFC 5987标准的Content-Disposition头部
-func generateContentDisposition(filename string) string {
-	// 按照RFC 2047进行编码，用于filename部分
-	encodedName := urlEncode(filename)
 
-	// 按照RFC 5987进行编码，用于filename*部分
-	encodedNameRFC5987 := encodeRFC5987(filename)
-
-	return fmt.Sprintf("attachment; filename=\"%s\"; filename*=utf-8''%s",
-		encodedName, encodedNameRFC5987)
-}
-
-// encodeRFC5987 按照RFC 5987规范编码字符串，适用于HTTP头部参数中的非ASCII字符
-func encodeRFC5987(s string) string {
-	var buf strings.Builder
-	for _, r := range []byte(s) {
-		// 根据RFC 5987，只有字母、数字和部分特殊符号可以不编码
-		if (r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			r == '-' || r == '.' || r == '_' || r == '~' {
-			buf.WriteByte(r)
-		} else {
-			// 其他字符都需要百分号编码
-			fmt.Fprintf(&buf, "%%%02X", r)
-		}
-	}
-	return buf.String()
-}
 
 func randomString() string {
 	const charset = "0123456789abcdefghijklmnopqrstuvwxyz"

--- a/drivers/doubao_share/driver.go
+++ b/drivers/doubao_share/driver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AlliotTech/openalist/internal/driver"
 	"github.com/AlliotTech/openalist/internal/errs"
 	"github.com/AlliotTech/openalist/internal/model"
+	"github.com/AlliotTech/openalist/pkg/utils"
 	"github.com/go-resty/resty/v2"
 	"net/http"
 )
@@ -104,7 +105,7 @@ func (d *DoubaoShare) Link(ctx context.Context, file model.Obj, args model.LinkA
 		}
 
 		// 生成标准的Content-Disposition
-		contentDisposition := generateContentDisposition(u.Name)
+		contentDisposition := utils.GenerateContentDisposition(u.Name)
 
 		return &model.Link{
 			URL: downloadUrl,

--- a/drivers/doubao_share/util.go
+++ b/drivers/doubao_share/util.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
 	"net/http"
-	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -707,38 +706,4 @@ func (d *DoubaoShare) listVirtualDirectoryContent(dir model.Obj) ([]model.Obj, e
 	return objects, nil
 }
 
-// generateContentDisposition 生成符合RFC 5987标准的Content-Disposition头部
-func generateContentDisposition(filename string) string {
-	// 按照RFC 2047进行编码，用于filename部分
-	encodedName := urlEncode(filename)
 
-	// 按照RFC 5987进行编码，用于filename*部分
-	encodedNameRFC5987 := encodeRFC5987(filename)
-
-	return fmt.Sprintf("attachment; filename=\"%s\"; filename*=utf-8''%s",
-		encodedName, encodedNameRFC5987)
-}
-
-// encodeRFC5987 按照RFC 5987规范编码字符串，适用于HTTP头部参数中的非ASCII字符
-func encodeRFC5987(s string) string {
-	var buf strings.Builder
-	for _, r := range []byte(s) {
-		// 根据RFC 5987，只有字母、数字和部分特殊符号可以不编码
-		if (r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			r == '-' || r == '.' || r == '_' || r == '~' {
-			buf.WriteByte(r)
-		} else {
-			// 其他字符都需要百分号编码
-			fmt.Fprintf(&buf, "%%%02X", r)
-		}
-	}
-	return buf.String()
-}
-
-func urlEncode(s string) string {
-	s = url.QueryEscape(s)
-	s = strings.ReplaceAll(s, "+", "%20")
-	return s
-}

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// GenerateContentDisposition 生成符合RFC 5987标准的Content-Disposition头部
+func GenerateContentDisposition(filename string) string {
+	// 按照RFC 2047进行编码，用于filename部分
+	encodedName := urlEncode(filename)
+
+	// 按照RFC 5987进行编码，用于filename*部分
+	encodedNameRFC5987 := encodeRFC5987(filename)
+
+	return fmt.Sprintf("attachment; filename=\"%s\"; filename*=utf-8''%s",
+		encodedName, encodedNameRFC5987)
+}
+
+// urlEncode URL编码函数，适用于文件名编码
+func urlEncode(s string) string {
+	s = url.QueryEscape(s)
+	s = strings.ReplaceAll(s, "+", "%20")
+	return s
+}
+
+// encodeRFC5987 按照RFC 5987规范编码字符串，适用于HTTP头部参数中的非ASCII字符
+func encodeRFC5987(s string) string {
+	var buf strings.Builder
+	for _, r := range []byte(s) {
+		// 根据RFC 5987，只有字母、数字和部分特殊符号可以不编码
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '-' || r == '.' || r == '_' || r == '~' {
+			buf.WriteByte(r)
+		} else {
+			// 其他字符都需要百分号编码
+			fmt.Fprintf(&buf, "%%%02X", r)
+		}
+	}
+	return buf.String()
+} 

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -93,7 +92,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 }
 func attachHeader(w http.ResponseWriter, file model.Obj) {
 	fileName := file.GetName()
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, fileName, url.PathEscape(fileName)))
+	w.Header().Set("Content-Disposition", utils.GenerateContentDisposition(fileName))
 	w.Header().Set("Content-Type", utils.GetMimeType(fileName))
 	w.Header().Set("Etag", GetEtag(file))
 }

--- a/server/handles/archive.go
+++ b/server/handles/archive.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/AlliotTech/openalist/internal/task"
-	"net/url"
 	stdpath "path"
 
 	"github.com/AlliotTech/openalist/internal/archive/tool"
@@ -391,11 +390,11 @@ func ArchiveInternalExtract(c *gin.Context) {
 		"Referrer-Policy": "no-referrer",
 		"Cache-Control":   "max-age=0, no-cache, no-store, must-revalidate",
 	}
-	filename := stdpath.Base(innerPath)
-	headers["Content-Disposition"] = fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, filename, url.PathEscape(filename))
+	fileName := stdpath.Base(innerPath)
+	headers["Content-Disposition"] = utils.GenerateContentDisposition(fileName)
 	contentType := c.Request.Header.Get("Content-Type")
 	if contentType == "" {
-		contentType = utils.GetMimeType(filename)
+		contentType = utils.GetMimeType(fileName)
 	}
 	c.DataFromReader(200, size, contentType, rc, headers)
 }

--- a/server/s3/backend.go
+++ b/server/s3/backend.go
@@ -121,8 +121,9 @@ func (b *s3Backend) HeadObject(ctx context.Context, bucketName, objectName strin
 	// hash := getFileHashByte(fobj)
 
 	meta := map[string]string{
-		"Last-Modified": node.ModTime().Format(timeFormat),
-		"Content-Type":  utils.GetMimeType(fp),
+		"Last-Modified":      node.ModTime().Format(timeFormat),
+		"Content-Disposition": utils.GenerateContentDisposition(path.Base(objectName)),
+		"Content-Type":       utils.GetMimeType(fp),
 	}
 
 	if val, ok := b.meta.Load(fp); ok {
@@ -213,8 +214,9 @@ func (b *s3Backend) GetObject(ctx context.Context, bucketName, objectName string
 	}
 
 	meta := map[string]string{
-		"Last-Modified": node.ModTime().Format(timeFormat),
-		"Content-Type":  utils.GetMimeType(fp),
+		"Last-Modified":      node.ModTime().Format(timeFormat),
+		"Content-Disposition": utils.GenerateContentDisposition(file.GetName()),
+		"Content-Type":       utils.GetMimeType(fp),
 	}
 
 	if val, ok := b.meta.Load(fp); ok {
@@ -328,7 +330,7 @@ func (b *s3Backend) PutObject(
 func (b *s3Backend) DeleteMulti(ctx context.Context, bucketName string, objects ...string) (result gofakes3.MultiDeleteResult, rerr error) {
 	for _, object := range objects {
 		if err := b.deleteObject(ctx, bucketName, object); err != nil {
-			utils.Log.Errorf("serve s3", "delete object failed: %v", err)
+			log.Errorf("delete object failed: %v", err)
 			result.Error = append(result.Error, gofakes3.ErrorResult{
 				Code:    gofakes3.ErrInternal,
 				Message: gofakes3.ErrInternal.Message(),


### PR DESCRIPTION
- Replaced the inline Content-Disposition generation in the Doubao and DoubaoShare drivers with a call to the new utils.GenerateContentDisposition function.
- Removed the redundant generateContentDisposition functions from both drivers.
- Updated related files to utilize the new utility function for consistent Content-Disposition header formatting.